### PR TITLE
Added support for saving multiple gamepad settings per project

### DIFF
--- a/addons/gamepad/gamepadlib.js
+++ b/addons/gamepad/gamepadlib.js
@@ -153,7 +153,7 @@ class GamepadData {
   }
 
   resetMappings() {
-    this.hints = this.gamepadLib.getHints();
+    this.hints = this.gamepadLib.getHints(this.gamepad.id, this.gamepad.index);
     this.buttonMappings = this.getDefaultButtonMappings().map(transformAndCopyMapping);
     this.axesMappings = this.getDefaultAxisMappings().map(transformAndCopyMapping);
   }
@@ -450,11 +450,11 @@ class GamepadLib extends EventTarget {
     });
   }
 
-  getHints() {
-    return Object.assign(defaultHints(), this.getUserHints());
+  getHints(gamepadId, gamepadIndex) {
+    return Object.assign(defaultHints(), this.getUserHints(gamepadId, gamepadIndex));
   }
 
-  getUserHints() {
+  getUserHints(gamepadId, gamepadIndex) {
     // to be overridden by users
     return {};
   }
@@ -1083,19 +1083,21 @@ class GamepadEditor extends EventTarget {
     }
   }
 
-  export() {
-    const selectedId = this.selector.value;
-    if (!selectedId) {
-      return null;
-    }
-    const gamepadData = this.gamepadLib.gamepads.get(selectedId);
-    if (!gamepadData) {
-      return null;
-    }
-    return {
-      axes: gamepadData.axesMappings.map(prepareAxisMappingForExport),
-      buttons: gamepadData.buttonMappings.map(prepareButtonMappingForExport),
-    };
+  exportSettings() {
+    const settingsMap = new Map();
+    // Add information about each gamepad to gamepadArray
+    this.gamepadLib.gamepads.forEach((gamepadData, gamepadKey, map) => {
+      // Add the gamepad's id (type), index, and current mappings to gamepadArray
+      settingsMap.set(gamepadKey, {
+        id: gamepadData.gamepad.id,
+        index: gamepadData.gamepad.index,
+        settings: {
+          axes: gamepadData.axesMappings.map(prepareAxisMappingForExport),
+          buttons: gamepadData.buttonMappings.map(prepareButtonMappingForExport),
+        },
+      });
+    });
+    return settingsMap;
   }
 
   changed() {

--- a/addons/gamepad/userscript.js
+++ b/addons/gamepad/userscript.js
@@ -60,8 +60,7 @@ export default async function ({ addon, console, msg }) {
     }
     return null;
   };
-  const parseOptionsComment = () => {
-    const comment = findOptionsComment();
+  const parseOptionsComment = (comment) => {
     if (!comment) {
       return null;
     }
@@ -71,27 +70,66 @@ export default async function ({ addon, console, msg }) {
       return null;
     }
     const jsonText = lineWithMagic.substr(0, lineWithMagic.length - GAMEPAD_CONFIG_MAGIC.length);
-    let parsed;
+    let storedSettingsMap = null;
     try {
-      parsed = JSON.parse(jsonText);
-      if (!parsed || typeof parsed !== "object" || !Array.isArray(parsed.buttons) || !Array.isArray(parsed.axes)) {
+      const parsed = JSON.parse(jsonText);
+      if (!parsed || typeof parsed !== "object") {
+        throw new Error("Invalid data");
+      }
+
+      // The older version of this addon only saved one set of settings with 2 arrays: .buttons and .axes
+      // This version saves an array of multiple gamepads and their settings
+      //   This code determines whether the project has an older comment (V1) in it or a newer comment (V2)
+      if (Array.isArray(parsed)) {
+        // Comment is in the new V2 style
+        // Convert the array back into a Map
+        storedSettingsMap = new Map(parsed);
+      } else if (Array.isArray(parsed.buttons) && Array.isArray(parsed.axes)) {
+        // Comment is in the old V1 style
+        // Convert to V2 style as a Map containing a single unlabeled gamepad
+        storedSettingsMap = new Map([
+          [
+            "", // No gamepad type/key to store
+            {
+              id: "", // No gamepad id to store
+              index: 0,
+              settings: {
+                axes: parsed.axes,
+                buttons: parsed.buttons,
+              },
+            },
+          ],
+        ]);
+      } else {
         throw new Error("Invalid data");
       }
     } catch (e) {
       console.warn("Gamepad comment has invalid JSON", e);
       return null;
     }
-    return parsed;
+    return storedSettingsMap;
   };
 
   GamepadLib.setConsole(console);
   const gamepad = new GamepadLib();
 
-  gamepad.getUserHints = () => {
-    const parsedOptions = parseOptionsComment();
-    if (parsedOptions) {
+  gamepad.getUserHints = (gamepadId, gamepadIndex) => {
+    const parsedOptionsMap = parseOptionsComment(findOptionsComment());
+    if (parsedOptionsMap) {
+      const optionsArray = Array.from(parsedOptionsMap.values());
+      let matchingOption;
+      // If a stored mapping exists for this exact gamepad id and index, use it
+      matchingOption = optionsArray.find((gamepads) => gamepads.id === gamepadId && gamepads.index === gamepadIndex);
+      if (!matchingOption) {
+        // Otherwise, if a stored mapping exists for this gamepad id at all, use it
+        matchingOption = optionsArray.find((gamepads) => gamepads.id === gamepadId);
+        if (!matchingOption) {
+          // Otherwise, use the first stored mapping no matter what it is
+          matchingOption = optionsArray.at(0);
+        }
+      }
       return {
-        importedSettings: parsedOptions,
+        importedSettings: matchingOption.settings,
       };
     }
     return {
@@ -146,17 +184,31 @@ export default async function ({ addon, console, msg }) {
       vm.emitWorkspaceUpdate();
     }
   };
+
+  const formatMapAsComment = (settingsMap) => {
+    // JSON.stringify does not work on Maps, so convert the Map to an array first
+    return `${msg("config-header")}\n${JSON.stringify(Array.from(settingsMap.entries()))}${GAMEPAD_CONFIG_MAGIC}`;
+  };
+
   const storeMappings = () => {
-    const exported = editor.export();
-    if (!exported) {
+    const exportedSettingsMap = editor.exportSettings();
+    if (!exportedSettingsMap) {
       console.warn("Could not export gamepad settings");
       return;
     }
-    const text = `${msg("config-header")}\n${JSON.stringify(exported)}${GAMEPAD_CONFIG_MAGIC}`;
     const existingComment = findOptionsComment();
     if (existingComment) {
-      existingComment.text = text;
-    } else {
+      const parsedExistingSettingsMap = parseOptionsComment(existingComment);
+      if (parsedExistingSettingsMap) {
+        // Merge the existing settings map with the new exported map
+        //   Making the exported settings the second merging map ensures that it takes priority in case of a conflict
+        const mergedMap = new Map([...parsedExistingSettingsMap, ...exportedSettingsMap]);
+        existingComment.text = formatMapAsComment(mergedMap);
+      } else {
+        existingComment = null;
+      }
+    }
+    if (!existingComment) {
       const target = vm.runtime.getTargetForStage();
       target.createComment(
         // comment ID, just has to be a random string
@@ -164,7 +216,7 @@ export default async function ({ addon, console, msg }) {
         // block ID
         null,
         // text
-        text,
+        formatMapAsComment(exportedSettingsMap),
         // x, y, width, height
         50,
         50,


### PR DESCRIPTION
### Reason for changes

**Multiplayer Scenario**
Recently I've been working on a local multiplayer game where you connect two gamepads to control two different players. The current gamepad addon can only save one of those configurations, meaning I have to re-write one configuration every time

**Multiple Different Gamepads Scenario**
Another issue is that if I have a game where I save a configuration for one type of gamepad (ex. an N64 controller), but I sometimes want to play the game with a different gamepad (ex. a Nintendo Pro Controller), then I need to re-write the 2nd controller's configuration every time

### Changes

Saving your gamepad settings now saves _every_ connected gamepad's configuration independently. Whenever you connect a gamepad, it will try to use the configuration that best matches it (it will prefer configurations that match the gamepad's type and index). The index matching handles multiple gamepads of the same type (i.e. in the case of the _Multiplayer Scenario_ above) while the type matching handles multiple different gamepads (i.e. in the case of the other scenario).

If you only ever use one gamepad in a project, then the addon functions exactly the same as it did before these changes. If you had a configuration saved previously (before upgrading to this version), then those settings are kept and will be used for newly connected gamepads

**Configuration Selection Logic**
When a gamepad is connected, it will perform the following logic to choose its configuration:

If a saved configuration with the same type and index as this gamepad is found, use it
else, if a saved configuration with the same type as this gamepad is found, use it
else, use the configuration that was saved earliest (the oldest one in the project)

### Tests

- Connected two gamepads of the same type and saved unique configurations for each
  - After reconnecting the gamepads, verified that each gamepad picked up its respective configuration
- Connected two gamepads of different types (ex. Xbox & Nintendo Joy-Con) and saved unique configurations for each
  - After reconnecting the gamepads, verified that each gamepad picked up its respective configuration
- Saved a setting using the older version of the addon, then upgraded to this version
  - After connecting a new gamepad, verified that the old configuration was used

Tested in Chrome and Edge